### PR TITLE
feature: use non-encoded string and endpoint alteration request

### DIFF
--- a/app/Http/Controllers/ProjectDocumentAccessController.php
+++ b/app/Http/Controllers/ProjectDocumentAccessController.php
@@ -76,7 +76,7 @@ class ProjectDocumentAccessController extends Controller
     {
         $request->validate([
             'document_id' => 'required|exists:project_documents,id',
-            'user_id' => 'required|exists:users,id'
+            'user_id' => 'required|exists:users,id' // TODO: user get by token/jwt/session
         ]);
 
         ProjectDocumentAccess::where('document_id', $request->document_id)

--- a/app/Http/Controllers/ProjectDocumentController.php
+++ b/app/Http/Controllers/ProjectDocumentController.php
@@ -45,24 +45,24 @@ class ProjectDocumentController extends Controller
                 case 'is':
                     $query->where('name', '=', $value);
                     break;
-                case 'is not':
+                case 'is_not':
                     $query->where('name', '!=', $value);
                     break;
-                case 'starts with':
+                case 'starts_with':
                     $query->where('name', 'like', $value . '%');
                     break;
-                case 'ends with':
+                case 'ends_with':
                     $query->where('name', 'like', '%' . $value);
                     break;
-                case 'does not contain':
+                case 'does_not_contain':
                     $query->where('name', 'not like', '%' . $value . '%');
                     break;
-                case 'is empty':
+                case 'is_empty':
                     $query->where(function ($qq) {
                         $qq->whereNull('name')->orWhere('name', '');
                     });
                     break;
-                case 'is not empty':
+                case 'is_not_empty':
                     $query->whereNotNull('name')->where('name', '!=', '');
                     break;
                 default:
@@ -563,12 +563,12 @@ class ProjectDocumentController extends Controller
 
         $uploader = User::find($document->uploaded_by);
 
-        
+
         if ($uploader) {
             try {
                 $uploader->notify(new DocumentRejected($document));
             } catch (\Exception $e) {
-                
+
                 Log::error('Failed to send DocumentRejected notification.', [
                     'user_id' => $uploader->id,
                     'document_id' => $document->id,

--- a/routes/api.php
+++ b/routes/api.php
@@ -105,7 +105,7 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/', 'store');
         Route::put('/', 'update');
         Route::get('/{id}', 'detail');
-        Route::post('/{id}', 'destroy');
+        Route::delete('/{id}', 'destroy');
         Route::post('/toggle-expiry', 'toggleExpiryReminder');
         Route::post('/approve', 'approveDocument');
         Route::post('/reject', 'rejectDocument');

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,7 +63,7 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/', 'store');
         Route::get('/{id}',  'detail');
         Route::put('/', 'update');
-        Route::delete('/', 'destroy');
+        Route::delete('/', 'destroy');  // TODO: use id in query param
         Route::post('/update-permission', 'updatePermission');
     });
 
@@ -73,7 +73,7 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/', 'store');
         Route::get('/{id}', 'detail');
         Route::put('/', 'update');
-        Route::delete('/', 'destroy');
+        Route::delete('/', 'destroy'); // TODO: use id in query param
         Route::get('/template/download',  'downloadTemplate');
         Route::post('/preview-import',  'previewImport');
         Route::post('/import',  'importUsers');
@@ -95,15 +95,15 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/', 'store');
         Route::get('/{id}', 'detail');
         Route::put('/', 'update');
-        Route::delete('/', 'destroy');
+        Route::delete('/', 'destroy'); // TODO: use id in query param
         Route::post('/bulk-assign', 'bulkAssignUsersToProjects');
     });
 
     //Project Document
     Route::prefix('project-documents')->controller(ProjectDocumentController::class)->group(function () {
         Route::get('/', 'index');
-        Route::post('/store', 'store');
-        Route::post('/update', 'update');
+        Route::post('/', 'store');
+        Route::put('/', 'update');
         Route::get('/{id}', 'detail');
         Route::post('/{id}', 'destroy');
         Route::post('/toggle-expiry', 'toggleExpiryReminder');
@@ -121,14 +121,14 @@ Route::middleware('auth:api')->group(function () {
     Route::prefix('project-document-comments')->controller(ProjectDocumentCommentController::class)->group(function () {
         Route::get('/{document_id}', 'index');
         Route::post('/', 'store');
-        Route::delete('/', 'destroy');
+        Route::delete('/', 'destroy'); // TODO: use id in query param
     });
 
     //Project Document Access
     Route::prefix('project-document-access')->controller(ProjectDocumentAccessController::class)->group(function () {
         Route::post('/invite', 'invite');
         Route::get('/{document_id}', 'listAccess');
-        Route::delete('/revoke', 'revokeAccess');
+        Route::delete('/revoke', 'revokeAccess'); // TODO: plese change to `/revoke/{document_id}`
     });
 
     // Project Assignment
@@ -142,7 +142,7 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/',  'store');
         Route::get('/{id}',  'detail');
         Route::put('/',  'update');
-        Route::delete('/',  'destroy');
+        Route::delete('/',  'destroy'); // TODO: use id in query param
     });
 
     // Project Status
@@ -151,7 +151,7 @@ Route::middleware('auth:api')->group(function () {
         Route::post('/', 'store');
         Route::get('/{id}', 'detail');
         Route::put('/', 'update');
-        Route::delete('/', 'destroy');
+        Route::delete('/', 'destroy'); // TODO: use id in query param
     });
 
     // Folder Template
@@ -162,7 +162,7 @@ Route::middleware('auth:api')->group(function () {
         Route::put('/single',  'updateSingle');
         Route::get('/{id}',  'detail');
         Route::put('/',  'update');
-        Route::delete('/',  'destroy');
+        Route::delete('/',  'destroy'); // TODO: use id in query param
     });
 
     // Notification


### PR DESCRIPTION
- using underscore instead of whitespace (whitespace will be encoded during http request and will behave unexpectedly)
- change `[POST] /strore` and `[POST] /update` to `[POST] /` and `[PUT] /`